### PR TITLE
ci: add GitHub Actions workflow with fmt, clippy, build and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --verbose
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --verbose


### PR DESCRIPTION
## 📝 Description

Ajout de la CI GitHub Actions avec 4 jobs :

  fmt — Vérification du formatage
  clippy — Linting Rust
  build — Compilation
  test — Tests

Déclenché sur push et PR vers main. Cache Cargo activé.

## 🎯 Issue liée

Fixes #3

## 🔄 Type de changement

- [ ] 🐛 **Bug fix**
- [x] ✨ **Feature**
- [ ] 💥 **Breaking change**
- [ ] 📚 **Documentation**
- [ ] 🔧 **Refactoring**
- [ ] 🧪 **Tests**

## ✅ Checklist

- [x] Mon code respecte les conventions du projet
- [x] J'ai testé mes changements localement
- [ ] Les tests passent (pas de tests)
- [ ] J'ai mis à jour la documentation si nécessaire (N/A)

## 🧪 Comment tester

1. Pusher la PR
2. Vérifier que les 4 jobs passent dans l'onglet Actions
3. Vérifier le badge CI sur le repo
